### PR TITLE
removed exec(ls -path) to just the path

### DIFF
--- a/config.php.template
+++ b/config.php.template
@@ -4,7 +4,7 @@
 
 */
 
-$cfgfile            = exec( "ls ~us3/lims/.us3lims.ini" );
+$cfgfile            = '/home/us3/lims/.us3lims.ini';
 $configs            = parse_ini_file( $cfgfile, true );
 $org_name           = 'UltraScan3 LIMS portal';
 $org_site           = 'uslims.uleth.ca/uslims3_instance';


### PR DESCRIPTION
Reduced $cfgfile to just the full path. Not sure why we need to do an exec( ls.. ) to get it.