### PR TITLE
Update queue_setup_3.php

### DIFF
--- a/queue_setup_3.php
+++ b/queue_setup_3.php
@@ -179,7 +179,7 @@ include 'header.php';
 
 <?php
 
-if ( isset( $_SESSION['request'] ) && sizeof( $_SESSION['request'] > 0 ) )
+if ( isset( $_SESSION['request'] ) && sizeof( $_SESSION['request'] ) > 0 )
 {
   $out_text = "";
   foreach ( $_SESSION['request'] as $removeID => $cellinfo )


### PR DESCRIPTION
Bugfix to sizeof(). - misplaced parens.  Discovered via a php warning during my tests: PHP Warning:  sizeof(): Parameter must be an array or an object that implements Countable in /srv/www/htdocs/uslims3/uslims3_et4/queue_setup_3.php on line 182.