### PR TITLE
QoL PR

### DIFF
--- a/2DSA_2.php
+++ b/2DSA_2.php
@@ -105,7 +105,7 @@ $missit_msg = "<br/>ds_remain=" . $ds_remain;
     {
 $missit_msg .= "<br/>composite=" . $composite;
 $missit_msg .= "<br/> kr=" . $kr;
-$missit_msg .= "<br/> fnkr=" . $filenames[kr];
+$missit_msg .= "<br/> fnkr=" . $filenames[$kr];
       $files_ok = false;
     }
 

--- a/queue_setup_1.php
+++ b/queue_setup_1.php
@@ -280,7 +280,7 @@ function get_experiment_text($link)
 
 //$time0=microtime(true);
   // Get a list of experiments
-  $query  = "SELECT   experimentID, DATE( dateUpdated ) AS udate, runID " .
+  $query  = "SELECT   experimentID, DATE( dateUpdated ) AS udate, runID, label " .
             "FROM     projectPerson, project, experiment " .
             "WHERE    projectPerson.personID = {$_SESSION['id']} " .
             "AND      project.projectID = projectPerson.projectID " .
@@ -293,12 +293,12 @@ function get_experiment_text($link)
                      "  onchange='this.form.submit();'>\n" .
                      "  <option value='null'>run ID not selected...</option>\n";
 
-  while ( list( $expID, $udate, $runID ) = mysqli_fetch_array( $result ) )
+  while ( list( $expID, $udate, $runID, $label ) = mysqli_fetch_array( $result ) )
   {
     $selected = ( $expID == $experimentID )
               ? " selected='selected'"
               : "";
-    $experiment_list .= "  <option value='$expID'$selected>$udate $runID</option>\n";
+    $experiment_list .= "  <option value='$expID'$selected>$udate $runID $label</option>\n";
   }
 //$time1=microtime(true)-$time0;
 //$experiment_list .= "  <option value=time1>$time1</option>\n";
@@ -387,7 +387,7 @@ function get_cell_text($link)
       list( $count ) = mysqli_fetch_array( $result );
 
       if ( $count > 0 )
-        $rawData_list .= "  <option value='$rawDataID:$filename'>$runID $filename</option>\n";
+        $rawData_list .= "  <option value='$rawDataID:$filename'>$filename</option>\n";
     }
 //$time3=microtime(true)-$time0;
 //$rawData_list .= "  <option value='time1time2time3'>$time1 $time2 $time3</option>\n";


### PR DESCRIPTION
This PR adds the labels of the experiment to the selectoptions in queue_setup_1 to make it easier for the user to select the correct experiment from the list of options.

Further more the runID is removed from the option text to select the triples to be analyzed. The runId is part of the displayed filename anyway and adds just more text and so more complexity to the user.

Lastly this PR fixes a typo in 2DSA_2 as kr doesn't exist as a global makro and $kr was probably the intention