### PR TITLE
Move the slow rss feed from queue_setup_1 to show_clusters

### DIFF
--- a/queue_setup_1.php
+++ b/queue_setup_1.php
@@ -194,37 +194,6 @@ HTML;
 
 motd_submit();
 
-// Add rss information from TACC
-require_once 'lib/rss_fetch.inc';
-
-//$time8=microtime(true) - $time0;
-$url = 'http://www.tacc.utexas.edu/rss/TACCUserNews.xml';
-$num_items = 3;
-$rss = fetch_rss($url);
-$items = array_slice($rss->items, 0, $num_items);
-//  $items = array();
-
-echo "<h3>{$rss->channel['title']}</h3>\n";
-
-// Generate table
-echo "<table cellpadding='7' cellspacing='0'>\n";
-foreach ( $items as $item )
-{
-  $title       = $item['title'];
-  $url         = $item['link'];
-  $description = $item['description'];
-
-  echo <<<HTML
-  <tr><td><a href=$url>$title</a></td>
-      <td>$description</td></tr>
-
-HTML;
-}
-echo "</table>\n";
-//$time9=microtime(true) - $time0;
-//echo "  <p>time8 = $time8 </p>";
-//echo "  <p>time9 = $time9 </p>";
-
 ?>
 
 </div>

--- a/show_clusters.php
+++ b/show_clusters.php
@@ -5,6 +5,7 @@
  * Show cluster info:
  *
  */
+$page_title = 'Clusters';
 include_once 'checkinstance.php';
 include 'header.php';
 include 'lib/utility.php';
@@ -13,8 +14,40 @@ include 'lib/utility.php';
 <div id='content'>
 	<h1 class="title">Current Status of Clusters:</h1>
 <p/>
+<div>
 <?php echo showClusters(); ?>
 </div>
+<div>
+    <?php
+    // Add rss information from TACC
+    require_once 'lib/rss_fetch.inc';
+
+    //$time8=microtime(true) - $time0;
+    $url = 'http://www.tacc.utexas.edu/rss/TACCUserNews.xml';
+    $num_items = 5;
+
+    $rss = fetch_rss($url);
+    echo "<h3>{$rss->channel['title']}</h3>\n";
+    $items = array_slice($rss->items, 0, $num_items);
+    //  $items = array();
+    // Generate table
+    //echo print_r($items, true);
+    echo "<table cellpadding='7' cellspacing='0'>\n";
+    foreach ( $items as $item )
+    {
+        $title       = $item['title'] ?? "";
+        $url         = $item['link'] ?? "";
+        $description = $item['description'] ?? "";
+        echo "<tr><td><a href=$url>$title</a></td> <td>$description</td></tr>";
+
+    }
+    echo "</table>\n";
 
 
+    //$time9=microtime(true) - $time0;
+    //echo "  <p>time8 = $time8 </p>";
+    //echo "  <p>time9 = $time9 </p>";
+    ?>
+</div>
+</div>
 <?php include 'footer.php'; ?>


### PR DESCRIPTION
This pull request includes changes to the handling of RSS feed information from TACC and minor updates to the page title in the `show_clusters.php` file. The most important changes include moving the RSS feed fetching logic from `queue_setup_1.php` to `show_clusters.php` and updating the page title.

Changes to RSS feed handling:

* [`queue_setup_1.php`](diffhunk://#diff-8aac0fafc49e5ffc49743a9652462cf44598bbd9fee26365dd96983fd60c5363L197-L227): Removed the code that fetched and displayed RSS feed information from TACC.
* [`show_clusters.php`](diffhunk://#diff-07d7a2250f698a486a3fddd7f3ccd1dd5bb1e6db590b346de7c5570aad26b335R17-R52): Added the code to fetch and display RSS feed information from TACC, including generating an HTML table to display the feed items.

Page title update:

* [`show_clusters.php`](diffhunk://#diff-07d7a2250f698a486a3fddd7f3ccd1dd5bb1e6db590b346de7c5570aad26b335R8): Added a new variable `$page_title` to set the page title to 'Clusters'.