### PR TITLE
Remove webmaster, search, and partner pages

### DIFF
--- a/data_security.php
+++ b/data_security.php
@@ -2,7 +2,7 @@
 /*
  * data_security.php
  *
- * A brief description of why we use https, and a link for the root certificate
+ * A brief description of why we use https and a link for the root certificate
  *
  */
 include 'checkinstance.php';
@@ -13,52 +13,84 @@ include 'config.php';
 $page_title = "Data Security";
 include 'header.php';
 ?>
-<!-- Begin page content -->
-<div id='content'>
+    <!-- Begin page content -->
+    <div id='content'>
 
-  <h1 class="title">Data Security</h1>
-  <!-- Place page content here -->
-  <p>This website uses the secure HTTP protocol (HTTPS) for logging in and for
-     most communication while you are logged in. What is HTTPS and why do we 
-     need it? Basically HTTPS is what we get when we layer HTTP, the language 
-     of the web, on top of the SSL protocol. By putting the SSL protocol into 
-     the mix we can add the security capabilities of SSL to regular web (HTTP) 
-     communications. Since regular HTTP communications take place over the 
-     internet connection in clear text, HTTPS is widely used on the web when 
-     extra security is needed. </p>
+        <h1 class="title">Data Security</h1>
 
-  <p>Because of this arrangement, HTTPS can communicate over what is often
-     called an <em>encrypted tunnel.</em> This includes the entire content
-     of what is sent in both directions. In this way you can be sure that
-     your login information, as well as any data and analysis parameters,
-     are being sent over the internet securely.</p>
+        <h2>HTTPS &amp; Encrypted Transport</h2>
 
-  <p>HTTPS uses <em>certificates</em> to establish the secure connection. This
-     is handled by your browser for the most part, so it is transparent
-     to you once it is set up correctly. On this website these certificates
-     are based on <a href='ssl/cacert.crt'>our certificate authority</a>.
-     Before logging in, if you have not done so already, please click on this 
-     link to accept our certificate authority. If you are using Firefox be sure
-     to check the box to trust this certficate authority to identify websites
-     in the dialog that pops up and click ok. If you are using Internet Explorer,
-     click the <em>Open</em> button to open the certificate file, and then in 
-     the dialog that pops up click on the button marked <em>Install certificate...</em>.
-     Then, in the Certificate Import Wizard, click the radio button that says
-     <em>Automatically select the certificate store based on the type of certificate</em>.
-     Finally, in the <em>Security Warning</em> dialog box confirming that you want
-     to install the certificate authority (CA) representing bcf.uthscsa.edu, click
-     <em>Yes</em>. Whichever browser you use, accepting our certificate authority
-     will help your browser identify our website and make it easier to use the 
-     secure parts of it.</p>
+        <p>This website uses <strong>HTTPS</strong> for all login sessions and
+            authenticated communications. HTTPS layers the <strong>TLS (Transport
+                Layer Security)</strong> protocol on top of standard web (HTTP) traffic,
+            creating an encrypted tunnel for everything transmitted between your
+            browser and our servers. This ensures that your login credentials,
+            analysis parameters, and experimental data cannot be read or tampered
+            with in transit, even on shared or public networks.</p>
 
-  <p>If you have any questions or problems with our certificate authority, please
-     contact us. Thanks!</p>
+        <h2>Two Environments, Two Certificate Types</h2>
 
-  <p><a href='mailto:demeler@biochem.uthscsa.edu'>Borries Demeler, Ph.D.</a><br/>
-  Professor<br/> 
-  UltraScan Project Director</p>
+        <p>UltraScan operates two distinct environments, each using a different
+            type of TLS certificate:</p>
 
-</div>
+        <ul>
+            <li><strong>Public-facing site</strong> &mdash; Uses a certificate issued
+                by a trusted public certificate authority (CA). Your browser will
+                recognize and trust it automatically with no additional steps
+                required.</li>
+
+            <li><strong>Private LIMS</strong> &mdash; Uses a self-signed certificate
+                within the internal LIMS environment. Self-signed certificates provide
+                the same encryption strength as CA-issued certificates; the only
+                difference is that they are not vouched for by a public CA. Because of
+                this, your browser will display a security warning the first time you
+                connect. This is expected &mdash; see the instructions below.</li>
+        </ul>
+
+        <h2>Accessing a Private LIMS</h2>
+
+        <p>When connecting to the private LIMS for the first time your browser will
+            show a warning such as <em>&ldquo;Your connection is not private&rdquo;</em>
+            or <em>&ldquo;Potential security risk ahead.&rdquo;</em> This is normal
+            for self-signed certificates in a controlled internal environment. Use
+            the steps below for your browser to proceed:</p>
+
+        <p><strong>Chrome / Edge</strong></p>
+        <ol>
+            <li>Click <em>Advanced</em> on the warning page.</li>
+            <li>Click <em>Proceed to [hostname] (unsafe)</em>. The label sounds alarming
+                but within the LIMS network this is the expected and correct path.</li>
+        </ol>
+
+        <p><strong>Firefox</strong></p>
+        <ol>
+            <li>Click <em>Advanced&hellip;</em> on the warning page.</li>
+            <li>Click <em>Accept the Risk and Continue</em>. Firefox will remember the
+                exception for subsequent sessions.</li>
+        </ol>
+
+        <p><strong>Safari</strong></p>
+        <ol>
+            <li>Click <em>Show Details</em> on the warning page.</li>
+            <li>Click <em>visit this website</em> and enter your macOS password if
+                prompted to confirm the trust decision.</li>
+        </ol>
+
+        <h2>Security Best Practices</h2>
+
+        <p>Even with HTTPS in place, a few habits help keep your account and data
+            secure:</p>
+
+        <ul>
+            <li>Always verify the address bar shows <strong>https://</strong> and the
+                correct hostname before entering your credentials.</li>
+            <li>Log out when you are finished, especially on shared workstations.</li>
+            <li>A certificate warning on the <em>public-facing site</em> would be
+                unexpected. If you see one there, please contact us before
+                proceeding.</li>
+        </ul>
+
+    </div>
 
 <?php
 include 'footer.php';

--- a/links.php
+++ b/links.php
@@ -54,9 +54,7 @@ $general_menu = <<<HTML
   <h4>General</h4>
   $change_my_info_if_not_PAM
   <a href='https://$org_site/view_database_info.php'>Database Login Info</a>
-  <a href="partners.php">Partners</a>
   <a href='contacts.php'>Contacts</a>
-  <a href='mailto:$admin_email'>Webmaster</a>
   <a href='data_security.php'>Data Security</a>
   <a href='http://$org_site/logout.php'>Logout</a>
 
@@ -65,9 +63,7 @@ HTML;
 $general_menu_1 = <<<HTML
   <h4>General</h4>
   $change_my_info_if_not_PAM
-  <a href="partners.php">Partners</a>
   <a href='contacts.php'>Contacts</a>
-  <a href='mailto:$admin_email'>Webmaster</a>
   <a href='data_security.php'>Data Security</a>
   <a href='http://$org_site/logout.php'>Logout</a>
 
@@ -155,9 +151,7 @@ else // not logged in
 {
   $sidebar_menu = <<<HTML
   <a href="http://$org_site/index.php">Welcome!</a>
-  <a href="partners.php">Partners</a>
   <a href='contacts.php'>Contacts</a>
-  <a href='mailto:$admin_email'>Webmaster</a>
   <a href='data_security.php'>Data Security</a>
   <a href='https://$org_site/login.php'>Login</a>
 

--- a/partners.php
+++ b/partners.php
@@ -1,1 +1,0 @@
-../partners.php

--- a/search.php
+++ b/search.php
@@ -1,1 +1,0 @@
-../search.php


### PR DESCRIPTION
This pull request updates the `data_security.php` page to improve clarity and guidance on HTTPS and certificate usage, and removes the obsolete `partners.php` and `search.php` pages along with their sidebar and menu links. The changes modernize the security documentation and streamline navigation by eliminating unused or redundant links.

**Security documentation improvements:**

* Rewrote the content in `data_security.php` to clearly explain HTTPS, TLS certificates, and the distinction between public and private environments, including step-by-step browser instructions for handling self-signed certificates and security best practices.
* Minor edit to the file header in `data_security.php` for clarity.

**Navigation and page cleanup:**

* Removed all references and links to `partners.php` and the webmaster email from the sidebar and general menus in `links.php`. [[1]](diffhunk://#diff-261982edfa6ef562383392e5ef988b21fc75aba0885a54dee9013b6171b5d9dbL57-L59) [[2]](diffhunk://#diff-261982edfa6ef562383392e5ef988b21fc75aba0885a54dee9013b6171b5d9dbL68-L70) [[3]](diffhunk://#diff-261982edfa6ef562383392e5ef988b21fc75aba0885a54dee9013b6171b5d9dbL158-L160)
* Deleted the obsolete `partners.php` and `search.php` pages. [[1]](diffhunk://#diff-15fca82411716796cc97bc376e0575b549d9f8c46296c558d1823f8fadefc1b1L1) [[2]](diffhunk://#diff-fe25e8545f067eb50fae0028b5dcdc76e168a985bd8806edcae066ae1f6a4f8bL1)