### PR TITLE
Ensure consistency in User Audit Log Menu Item

### DIFF
--- a/admin_links.php
+++ b/admin_links.php
@@ -70,7 +70,7 @@ $edituser_menu_level_0 = <<<HTML
       <li><a href='https://$org_site/edit_users.php'>Edit User Info</a></li>
       <li><a href='https://$org_site/view_users.php'>View User Info</a></li>
       <li><a href='https://$org_site/view_all.php'>View All Users</a></li>
-      <li><a href='https://$org_site/view_people_audit.php'>People Audit Log</a></li>
+      <li><a href='https://$org_site/view_people_audit.php'>User Audit Log</a></li>
 HTML;
 
 $hardware_menu = <<<HTML


### PR DESCRIPTION
This pull request makes a small wording change in the admin links menu to improve clarity.

- Changed the menu link text from "People Audit Log" to "User Audit Log" in `admin_links.php` for consistency and clarity.