### PR TITLE
Surface job submission failures on the "job accepted" confirmation page

### DIFF
--- a/2DSA-CG_2.php
+++ b/2DSA-CG_2.php
@@ -216,6 +216,16 @@ HTML;
       {
         $output_msg .= "<br /><span class='message'>Message from the queue...</span><br />\n" .
                         print_r( $retval, true ) . " <br />\n";
+
+        foreach ( $retval as $rmsg )
+        {
+          if ( is_string( $rmsg ) && preg_match( '/^ERROR:/', $rmsg ) )
+          {
+            $output_msg .= "<br /><span class='message' style='color:red;font-weight:bold;'>" .
+                            "WARNING: job submission failed - $rmsg</span><br />\n";
+            break;
+          }
+        }
       }
 else {
 $output_msg .= "<br /><span class='message'>Message from the queue...filename=$filename</span><br/>\n";

--- a/2DSA_2.php
+++ b/2DSA_2.php
@@ -226,6 +226,16 @@ HTML;
       {
         $output_msg .= "<br /><span class='message'>Message from the queue...</span><br />\n" .
                         print_r( $retval, true ) . " <br />\n";
+
+        foreach ( $retval as $rmsg )
+        {
+          if ( is_string( $rmsg ) && preg_match( '/^ERROR:/', $rmsg ) )
+          {
+            $output_msg .= "<br /><span class='message' style='color:red;font-weight:bold;'>" .
+                            "WARNING: job submission failed - $rmsg</span><br />\n";
+            break;
+          }
+        }
       }
 else {
 $output_msg .= "<br /><span class='message'>Message from the queue...filename=$filename</span><br/>\n";

--- a/DMGA_2.php
+++ b/DMGA_2.php
@@ -177,6 +177,16 @@ HTML;
       {
         $output_msg .= "<br /><span class='message'>Message from the queue...</span><br />\n" .
                         print_r( $retval, true ) . " <br />\n";
+
+        foreach ( $retval as $rmsg )
+        {
+          if ( is_string( $rmsg ) && preg_match( '/^ERROR:/', $rmsg ) )
+          {
+            $output_msg .= "<br /><span class='message' style='color:red;font-weight:bold;'>" .
+                            "WARNING: job submission failed - $rmsg</span><br />\n";
+            break;
+          }
+        }
       }
     }
 

--- a/GA_3.php
+++ b/GA_3.php
@@ -180,6 +180,16 @@ HTML;
       {
         $output_msg .= "<br /><span class='message'>Message from the queue...</span><br />\n" .
                         print_r( $retval, true ) . " <br />\n";
+
+        foreach ( $retval as $rmsg )
+        {
+          if ( is_string( $rmsg ) && preg_match( '/^ERROR:/', $rmsg ) )
+          {
+            $output_msg .= "<br /><span class='message' style='color:red;font-weight:bold;'>" .
+                            "WARNING: job submission failed - $rmsg</span><br />\n";
+            break;
+          }
+        }
       }
     }
 

--- a/PCSA_2.php
+++ b/PCSA_2.php
@@ -215,6 +215,16 @@ HTML;
       {
         $output_msg .= "<br /><span class='message'>Message from the queue...</span><br />\n" .
                         print_r( $retval, true ) . " <br />\n";
+
+        foreach ( $retval as $rmsg )
+        {
+          if ( is_string( $rmsg ) && preg_match( '/^ERROR:/', $rmsg ) )
+          {
+            $output_msg .= "<br /><span class='message' style='color:red;font-weight:bold;'>" .
+                            "WARNING: job submission failed - $rmsg</span><br />\n";
+            break;
+          }
+        }
       }
     }
 


### PR DESCRIPTION
## Summary
- `2DSA_2.php`, `2DSA-CG_2.php`, `PCSA_2.php`, `GA_3.php`, and `DMGA_2.php` each print a "Thank you, your job was accepted and is currently processing" banner unconditionally, before checking `$job->get_messages()`.
- If submission actually fails (e.g. the `sbatch` failure case fixed in ehb54/us3lims_common#21), the only sign was an `ERROR:`-prefixed line buried inside a raw `print_r()` dump below the success banner.
- Scans the queue messages for an `ERROR:`-prefixed line and surfaces a clear, visible warning when found, without touching the existing unconditional banner or control flow (composite/multi-dataset submissions can have a mix of success/failure across `$filenames`, so the banner intentionally still means "request accepted for processing," not "every sub-job succeeded").
- These `_2.php` pages are also reached via CLI-based submission (`us3lims_gridctl`'s `submitctl.php`/`submitone.php`, through the `$is_cli` include path) — this change is purely additive HTML/text appended to the existing message buffer, so it behaves identically in both contexts.
- Does not affect automated GMP/autoflow failure handling, which already correctly polls `autoflowAnalysis.status` (`SUBMIT_TIMEOUT`, from ehb54/us3lims_common#21). This is purely about human-readability of the confirmation output.
- A related but separate gap — `submitone.php` itself not detecting this failure mode for its own CLI error tracking — is tracked in ehb54/ultrascan-tickets#917.

Fixes ehb54/ultrascan-tickets#916

## Test plan
- [x] Submit a normal successful job through each of the five affected pages and confirm the banner/output is unchanged
- [x] Simulate an `sbatch` failure (per ehb54/us3lims_common#21's test plan) and confirm the new red "WARNING: job submission failed - ..." line appears alongside the existing message dump
- [x] Confirm CLI-based submission (via `submitone.php`) still completes without error (the change is additive only)
